### PR TITLE
Added option to create .Rproj file based on user selection of R language

### DIFF
--- a/create-project.sh
+++ b/create-project.sh
@@ -79,5 +79,39 @@ for file in "${files[@]}"; do
     echo "Created $path/$file"
 done
 
+# Adjust directories based on the -l selection for R
+# Only if R is selected
+if [[ "$lang" == "r" ]]; then
+  R -e "
+  if (!require('usethis', quietly = TRUE)){
+    install.packages('usethis', repos='http://cran.us.r-project.org')}
+
+  usethis::create_project(normalizePath('$path', winslash = '/'),
+    rstudio = TRUE,
+    open = rlang::is_interactive())
+  
+  use_git(message = \"Initial commit\")
+  
+  q(save = 'no')"
+  cd $path
+  rm -r R # Remove the default R directory created by usethis. Maybe we should keep it?
+
+# Only if R is selected and the path is not empty
+elif [[ "$lang" == "r" && -n "$path" ]]; then
+  R -e "
+  if (!require('usethis', quietly = TRUE)){
+    install.packages('usethis', repos='http://cran.us.r-project.org')}
+
+  usethis::create_project(normalizePath('$path', winslash = '/'),
+    rstudio = TRUE,
+    open = rlang::is_interactive())
+  
+  use_git(message = \"Initial commit\")
+  
+  q(save = 'no')"
+  cd $path
+  rm -r R # Remove the default R directory created by usethis. Maybe we should keep it?
+fi
+
 echo "Project structure created successfully at $path!"
 


### PR DESCRIPTION
This update introduces a new .Rproj environment with default settings. Additionally, Git is initialized for version control, all using usethis::create_project() and usethis::use_git() functions.

# Changes

1. New Project Environment:

- The project environment is created using usethis::create_project(), ensuring the .Rproj file is properly configured for RStudio workflows.

2. Git Initialization:

- Git is set up using usethis::use_git(), enabling version control right from the start.

3. Directory Cleanup:

- After project creation, the /R subdirectory is removed to avoid conflicts with the existing /src directory structure, as the source files are managed separately.

# Caveat

- If creating in a directory that already has Git initialized it will not create .Rproj file
- *This need further thought and debugging!*

# Next Steps

- Navigate into the newly created directory, confirm that all configurations are properly set up, and begin using Git for version tracking.