### PR TITLE
Enhancements to R Project Setup

### DIFF
--- a/create-project.sh
+++ b/create-project.sh
@@ -79,5 +79,39 @@ for file in "${files[@]}"; do
     echo "Created $path/$file"
 done
 
+# Adjust directories based on the -l selection for R
+# Only if R is selected
+if [[ "$lang" == "r" ]]; then
+  R -e "
+  if (!require('usethis', quietly = TRUE)){
+    install.packages('usethis', repos='http://cran.us.r-project.org')}
+
+  usethis::create_project(normalizePath('$path', winslash = '/'),
+    rstudio = TRUE,
+    open = rlang::is_interactive())
+  
+  use_git(message = \"Initial commit\")
+  
+  q(save = 'no')"
+  cd $path
+  rm -r R # Remove the default R directory created by usethis. Maybe we should keep it?
+
+# Only if R is selected and the path is not empty
+elif [[ "$lang" == "r" && -n "$path" ]]; then
+  R -e "
+  if (!require('usethis', quietly = TRUE)){
+    install.packages('usethis', repos='http://cran.us.r-project.org')}
+
+  usethis::create_project(normalizePath('$path', winslash = '/'),
+    rstudio = TRUE,
+    open = rlang::is_interactive())
+  
+  use_git(message = \"Initial commit\")
+  
+  q(save = 'no')"
+  cd $path
+  rm -r R # Remove the default R directory created by usethis. Maybe we should keep it?
+fi
+
 echo "Project structure created successfully at $path!"
 


### PR DESCRIPTION
## Summary

This PR introduces changes to the R project setup process, with minimal changes to the base R environment. The enhancements are triggered when the `-l r` flag is passed during the project creation.

## Changes

1. **Creation of .Rproj file:** A .Rproj file is now created as a simple text file with default settings. This file is essential for RStudio to recognize the directory as an non-package R project.

2. **Integration with `renv` for dependency management:** If the `-l r` flag is passed, the script checks if `renv` is installed. If not, it installs `renv` in the base R environment. It then runs `renv::init(project = '$path')` to create an `renv.lock` file and an `renv` folder. These are used to manage the R package dependencies for the project. If no path is specified, `renv::init()` sets the current directory as the project directory.

## Notes

This is a basic setup for an R project. There are other alternatives for more comprehensive project setups, such as using the `usethis` package. Future enhancements could consider integrating `usethis` or other project management tools for R.

## Testing

Please test this PR by creating a new R project with the `-l r` flag, as well as `-l r -p "PATH/HERE", to  verify that the .Rproj file, `renv.lock` file, and `renv` folder are created in the desired directory. 