### PR TITLE
R project environments

### DIFF
--- a/create-project.sh
+++ b/create-project.sh
@@ -79,52 +79,21 @@ for file in "${files[@]}"; do
     echo "Created $path/$file"
 done
 
-# Create a .Rproj text file with defaults if R is selected
-Rproj="Version: 1.0
-
-RestoreWorkspace: No
-SaveWorkspace: No
-AlwaysSaveHistory: Default
-
-EnableCodeIndexing: Yes
-UseSpacesForTab: Yes
-NumSpacesForTab: 4
-Encoding: UTF-8
-
-RnwWeave: knitr
-LaTeX: XeLaTeX
-
-AutoAppendNewline: Yes
-StripTrailingWhitespace: Yes
-LineEndingConversion: Posix"
-
-# Name the .Rproj file based on the directory name
-if [ "$lang" == "r" ]; then
-dir_name=$(basename "$PWD") # Get the name of the current directory name when path = "." for the .Rproj file. Necessary when creating text .Rproj file. Not necessary if we using usethis::create_project()
-  echo "$Rproj" > $path/$dir_name.Rproj
-elif [[ "$lang" == "r" && -n "$path" ]]; then
-  echo "$Rproj" > $path/$path.Rproj
-fi
-
-# Adjust directories based on the -l selection for R
-# Only if R is selected
- if [[ "$lang" == "r" ]]; then
+# Only if R is selected and the path is not empty
+# 1. If not already installed, install renv in the base R env as it's best practice to use project envs
+# 2. Initialize the project env in the project path
+# 3. Install usethis
+# 4. Create an RStudio .Rproj file
+ if [[ "$lang" == "r" && -n "$path" ]]; then
    R -e "
    if (!require('renv', quietly = TRUE)){
      install.packages('renv', repos='http://cran.us.r-project.org')}
    
    renv::init(project = '$path')
-   q(save = 'no')"
-
-# # Only if R is selected and the path is not empty
- elif [[ "$lang" == "r" && -n "$path" ]]; then
-   R -e "
-   if (!require('renv', quietly = TRUE)){
-     install.packages('renv', repos='http://cran.us.r-project.org')}
-   
-   renv::init(project = '$path')
+   renv::install('usethis')
+   usethis::create_project(path = '.', rstudio=TRUE, open=FALSE)
    q(save = 'no')"
  fi
 
-
+# The end
 echo "Project structure created successfully at $path!"

--- a/create-project.sh
+++ b/create-project.sh
@@ -79,5 +79,39 @@ for file in "${files[@]}"; do
     echo "Created $path/$file"
 done
 
+# Adjust directories based on the -l selection for R
+# Only if R is selected
+if [[ "$lang" == "r" ]]; then
+  R -e "
+  if (!require('usethis', quietly = TRUE)){
+    install.packages('usethis', repos='http://cran.us.r-project.org')}
+
+  usethis::create_project(normalizePath('$path', winslash = '/'),
+    rstudio = TRUE,
+    open = rlang::is_interactive())
+  
+  use_git(message = \"Initial commit\")
+  
+  q(save = 'no')"
+  cd $path
+  rm -r R # Remove the default R directory created by usethis. Maybe we should keep it?
+
+# Only if R is selected and the path is not empty
+elif [[ "$lang" == "r" && -n "$path" ]]; then
+  R -e "
+  if (!require('usethis', quietly = TRUE)){
+    install.packages('usethis', repos='http://cran.us.r-project.org')}
+
+  usethis::create_project(normalizePath('$path', winslash = '/'),
+    rstudio = TRUE,
+    open = rlang::is_interactive())
+  
+  use_git(message = \"Initial commit\")
+  
+  q(save = 'no')"
+  cd $path
+  rm -r R # Remove the default R directory created by usethis. Maybe we should keep it?
+fi
+
 echo "Project structure created successfully at $path!"
 


### PR DESCRIPTION
Based on the proposed idea from PR.

When -l r and -p path are specified, then:

1. install renv in the base r env to nudge users to use project environments
2. initialize the project environment
3. install usethis
4. call usethis::create_project(path = '.', rstudio=TRUE, open=FALSE) to programmatically create an .Rproj file