### PR TITLE
create-project.sh fixed nested dir issue with usethis::create_project(path='.')

### DIFF
--- a/create-project.sh
+++ b/create-project.sh
@@ -91,7 +91,7 @@ done
    
    renv::init(project = '$path')
    renv::install('usethis')
-   usethis::create_project(path = '.', rstudio=TRUE, open=FALSE)
+   usethis::create_project(path = '$path', rstudio=TRUE, open=FALSE)
    q(save = 'no')"
  fi
 


### PR DESCRIPTION
Updated the path arg in usethis::create_project from '.' to '$path' (the shell path arg)

This fixed the nested dir issue I encountered previously.

addresses #5 