### PR TITLE
Added powershell script for Windows, make -p flag required, removed creating rproj file in shell script

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Below are some examples.
 	- Windows
 		- choose the `.ps1` extension
 
-### Optional Flags
+### Flags
 
 - `-l`: Programming language flag
   - Only affects the testing directory
@@ -81,8 +81,8 @@ Below are some examples.
     - `python`
     - `jl`
     - `julia`
-  - **WARNING** only one option should be specified, there is no guardrail if more than one option is passed
-- `-p`: Project directory (required)
+  - **WARNING** only one language should be specified, there is no guardrail if more than one option is passed
+- `-p`: Project directory (**required**)
   - Takes any *existing* path
 
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 The purpose of this work is to create a language agnostic project template for data analysis.
 
-## Insipration
+## Inspiration
 
 I work with Julia, Python, and R.
 While the language-specific conventions are different the projects are usually structured similarly.
@@ -20,7 +20,8 @@ So, I decided that it would helpful to automate and standardize the steps prior 
 
 ## Operating Systems
 
-Currently focused on Ubuntu-based Linux distros, such as Linux Mint but the setup script should work for most Linux distros.
+- Linux (shell)
+- Windows (powershell)
 
 ## Language-Specific Conventions
 
@@ -60,7 +61,13 @@ Below are some examples.
 
 1. git clone repo
 2. Open a terminal and navigate to ^
-3. within the terminal run `chmod +x create-project.sh`
+3. select the appropriate file based on your OS
+
+	- Linux:
+		- choose the `.sh` extension
+		- within the terminal run `chmod +x create-project.sh`
+	- Windows
+		- choose the `.ps1` extension
 
 ### Optional Flags
 
@@ -75,9 +82,9 @@ Below are some examples.
     - `jl`
     - `julia`
   - **WARNING** only one option should be specified, there is no guardrail if more than one option is passed
-- `-p`: Project directory
-  - Takes any *existing* path; e.g., `./create-project.sh -p ~/Documents/proj-root`
-  - Otherwise the results will be created in the current directory
+- `-p`: Project directory (required)
+  - Takes any *existing* path
+
 
 ## Examples
 
@@ -88,22 +95,22 @@ mkdir git
 cd git
 git clone https://github.com/SaintRod/multi-lang-project-template.git
 cd multi-lang-project-template
-chmod +x create-project.sh
+chmod +x create-project.sh #linux only
 ```
 
 A) No clue what language will be used, and the project hasn't been started
 
-The following will create the results in the current directory.
-Copy/cut and paste the results to the project root directory when it's been created.
-
+Create the project structure in the current directory
 
 ```
-./create-project.sh
+create-project.sh -p . #linux
+multi-lang-project-template\create-project.ps1 -p . #windows
 ```
 
 B) No clue what language will be used, and the project root directory exists
 ```
-./create-project.sh -p ~/.../project-root
+./create-project.sh -p ~/.../project-root #linux
+.\create-project.ps1 -p ~\...\project-root #windows
 ```
 
 C) You know what language will be used, and the project root directory exists
@@ -112,43 +119,36 @@ C) You know what language will be used, and the project root directory exists
 ./create-project.sh -l r -p ~/.../project-root
 ./create-project.sh -l R -p ~/.../project-root
 
+.\create-project.ps1 -l r -p ~\...\project-root
+.\create-project.ps1 -l R -p ~\...\project-root
+
+
 # Python
-./create-project.sh -l py -p ~/.../project-root
+./create-project.sh -l py     -p ~/.../project-root
 ./create-project.sh -l python -p ~/.../project-root
-./create-project.sh -l PY -p ~/.../project-root
+./create-project.sh -l PY     -p ~/.../project-root
 ./create-project.sh -l PYTHON -p ~/.../project-root
 ./create-project.sh -l pYtHoN -p ~/.../project-root
 
+.\create-project.ps1 -l py     -p ~\...\project-root
+.\create-project.ps1 -l python -p ~\...\project-root
+.\create-project.ps1 -l PY     -p ~\...\project-root
+.\create-project.ps1 -l PYTHON -p ~\...\project-root
+.\create-project.ps1 -l pYtHoN -p ~\...\project-root
+
+
 # Julia
-./create-project.sh -l jl -p ~/.../project-root
+./create-project.sh -l jl    -p ~/.../project-root
 ./create-project.sh -l julia -p ~/.../project-root
-./create-project.sh -l JL -p ~/.../project-root
-./create-project.sh -l jL -p ~/.../project-root
+./create-project.sh -l JL    -p ~/.../project-root
+./create-project.sh -l jL    -p ~/.../project-root
+
+.\create-project.ps1 -l jl    -p ~\...\project-root
+.\create-project.ps1 -l julia -p ~\...\project-root
+.\create-project.ps1 -l JL    -p ~\...\project-root
+.\create-project.ps1 -l jL    -p ~\...\project-root
 ```
 
-D) You know what language will be used, but the project root directory doesn't exist
-
-In this scenario the results will be created in the current directory.
-When the project directory exists, copy/cut and paste the results there.
-
-```
-# R
-./create-project.sh -l r
-./create-project.sh -l R
-
-# Python
-./create-project.sh -l py
-./create-project.sh -l python
-./create-project.sh -l PY
-./create-project.sh -l PYTHON
-./create-project.sh -l pYtHoN
-
-# Julia
-./create-project.sh -l jl
-./create-project.sh -l julia
-./create-project.sh -l JL
-./create-project.sh -l jL
-```
 
 ### Results
 

--- a/create-project.ps1
+++ b/create-project.ps1
@@ -1,0 +1,118 @@
+<#
+.SYNOPSIS
+  Creates a standardized, language-agnostic data-analysis project file structure on Windows.
+
+.DESCRIPTION
+  PowerShell translation of create-project.sh.
+
+  Purpose: create folders and placeholder files only (no language-specific tooling).
+
+  - Creates directories:
+      data, data/input, data/output, docs, config, notebooks, src, scripts
+    plus language-specific test folders:
+      * R / Python  -> tests
+      * Julia       -> test
+      * unspecified -> test and tests
+
+  - Creates files:
+      .gitignore, LICENSE, README.md
+
+
+.PARAMETER Language
+  Language selector. Accepted (case-insensitive): r, py, python, jl, julia.
+
+.PARAMETER Path
+  Existing directory path where the structure will be created.
+  Required. Use -p . to target the current directory explicitly.
+
+.EXAMPLE
+  .\create-project.ps1 -p .
+
+.EXAMPLE
+  .\create-project.ps1 -l python -p C:\work\myproj
+
+.EXAMPLE
+  # If script execution is blocked:
+  powershell -ExecutionPolicy Bypass -File .\create-project.ps1 -l r -p C:\work\myproj
+#>
+
+[CmdletBinding()]
+param(
+    [Alias('l')]
+    [string]$Language = '',
+
+    [Alias('p')]
+    [Parameter(Mandatory=$true)]
+    [ValidateNotNullOrEmpty()]
+    [string]$Path,
+
+    [switch]$Help
+)
+
+if ($Help) {
+    Get-Help -Detailed $MyInvocation.MyCommand.Path
+    return
+}
+
+function To-Lower([string]$s) {
+    if ([string]::IsNullOrWhiteSpace($s)) { return '' }
+    return $s.ToLowerInvariant()
+}
+
+$lang = To-Lower $Language
+$targetPath = $Path
+
+if (-not (Test-Path -LiteralPath $targetPath -PathType Container)) {
+    Write-Error "Error: The specified path '$targetPath' does not exist."
+    exit 1
+}
+
+# Resolve to a full path for cleaner output and for downstream tooling
+$targetPath = (Resolve-Path -LiteralPath $targetPath).Path
+
+# Default directories
+$dirs = @(
+    'data',
+    'data/input',
+    'data/output',
+    'docs',
+    'config',
+    'notebooks',
+    'src',
+    'scripts'
+)
+
+# Define files
+$files = @(
+    '.gitignore',
+    'LICENSE',
+    'README.md'
+)
+
+# Adjust directories based on language flag
+switch ($lang) {
+    { $_ -in @('r','py','python') } { $dirs += 'tests' ; break }
+    { $_ -in @('jl','julia') }       { $dirs += 'test'  ; break }
+    default                          { $dirs += @('test','tests') }
+}
+
+Write-Host "Creating directories at $targetPath..."
+foreach ($dir in $dirs) {
+    $fullDir = Join-Path -Path $targetPath -ChildPath $dir
+    New-Item -ItemType Directory -Path $fullDir -Force | Out-Null
+    Write-Host "Created $fullDir"
+}
+
+Write-Host "Creating files at $targetPath..."
+foreach ($file in $files) {
+    $fullFile = Join-Path -Path $targetPath -ChildPath $file
+    if (-not (Test-Path -LiteralPath $fullFile -PathType Leaf)) {
+        New-Item -ItemType File -Path $fullFile -Force | Out-Null
+    } else {
+        # Keep existing file; touch equivalent by updating LastWriteTime
+        (Get-Item -LiteralPath $fullFile).LastWriteTime = Get-Date
+    }
+    Write-Host "Created $fullFile"
+}
+
+Write-Host "Project structure created successfully at $targetPath!"

--- a/create-project.sh
+++ b/create-project.sh
@@ -90,8 +90,6 @@ done
      install.packages('renv', repos='http://cran.us.r-project.org')}
    
    renv::init(project = '$path')
-   renv::install('usethis')
-   usethis::create_project(path = '$path', rstudio=TRUE, open=FALSE)
    q(save = 'no')"
  fi
 

--- a/create-project.sh
+++ b/create-project.sh
@@ -24,7 +24,7 @@ files=(
 # -l flag for language-specific directories
 # -p path
 lang=""
-path="."
+path=""
 
 # Function to convert string to lowercase
 to_lowercase() {
@@ -49,6 +49,12 @@ while getopts ":l:p:" opt; do
     ;;
   esac
 done
+
+# Enforce required -p flag (no implicit current-directory behavior)
+if [[ -z "$path" ]]; then
+  echo "Error: -p <path> is required. Use -p . to target the current directory." >&2
+  exit 1
+fi
 
 # Check if the specified path exists
 if [[ ! -d "$path" ]]; then


### PR DESCRIPTION
Added a new file to standardize and streamline the creation of project structures in Windows OS.

Updated scripts to make the `-p` flag required vs optional to avoid surprises, such as creating undesired folders in the current directory.

In the Linux shell script, I propose removing the creation of the Rproj file in favor of using Positron vs RStudio IDE. Initialization of a `renv` environment proceeds if the system can find an R executable.